### PR TITLE
feat: add Header component and routing for about and blog pages

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,74 @@
+import { Link } from "@tanstack/react-router";
+
+const Header = () => {
+	return (
+		<>
+			<header className="flex justify-center sticky top-0 z-40 w-full border-b bg-black">
+				<div className="container flex h-16 items-center justify-between">
+					<div className="flex items-center gap-2">
+						<Link to="/" className="text-xl font-bold text-white">
+							DevPortfolio
+						</Link>
+					</div>
+					<nav className="hidden md:flex gap-6">
+						<Link
+							to="/"
+							className="text-sm font-medium text-white hover:text-gray-300 transition-colors"
+						>
+							Inicio
+						</Link>
+						<a
+							href="#about"
+							className="text-sm font-medium text-white hover:text-gray-300 transition-colors"
+						>
+							Sobre mí
+						</a>
+						<a
+							href="#experience"
+							className="text-sm font-medium text-white hover:text-gray-300 transition-colors"
+						>
+							Experiencia
+						</a>
+						<a
+							href="#portfolio"
+							className="text-sm font-medium text-white hover:text-gray-300 transition-colors"
+						>
+							Portafolio
+						</a>
+						<Link
+							to="/blog"
+							className="text-sm font-medium text-white hover:text-gray-300 transition-colors"
+						>
+							Blog
+						</Link>
+						<a
+							href="#contact"
+							className="text-sm font-medium text-white hover:text-gray-300 transition-colors"
+						>
+							Contacto
+						</a>
+					</nav>
+					{/* <Button variant="outline" className="md:hidden" size="icon">
+						<svg
+							width="24"
+							height="24"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							className="h-5 w-5"
+						>
+							<line x1="4" x2="20" y1="12" y2="12" />
+							<line x1="4" x2="20" y1="6" y2="6" />
+							<line x1="4" x2="20" y1="18" y2="18" />
+						</svg>
+					</Button> */}
+				</div>
+			</header>
+		</>
+	);
+};
+
+export { Header };

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/about')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/about"!</div>
+}

--- a/src/routes/blog.tsx
+++ b/src/routes/blog.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/blog")({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	return <div>Hello "/blog"!</div>;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Header } from "../components/Header";
+
+export const Route = createFileRoute("/")({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	return (
+		<>
+			<Header />
+		</>
+	);
+}


### PR DESCRIPTION
This pull request introduces a new header component and sets up routing for the application using `@tanstack/react-router`. The most important changes include the creation of the `Header` component and the addition of routes for the home, about, and blog pages.

### New Header Component:

* [`src/components/Header.tsx`](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fR1-R74): Created a new `Header` component with navigation links to various sections of the site, including "Inicio", "Sobre mí", "Experiencia", "Portafolio", "Blog", and "Contacto". The header is styled to be sticky and responsive.

### Routing Setup:

* [`src/routes/index.tsx`](diffhunk://#diff-3d4d2177c21702138c6c0473b20d38d819dec2249dd99cbf1d00fde1f6ac5115R1-R14): Added a route for the home page that includes the new `Header` component.
* [`src/routes/about.tsx`](diffhunk://#diff-33f97434c2684d3ba2d517404a18b7d6a89227d0a163c4c5de43e609bc3a1d0dR1-R9): Added a route for the about page with a simple "Hello '/about'!" message.
* [`src/routes/blog.tsx`](diffhunk://#diff-f7fe8b65b830d66df34c0f839a56ab1771b5cc800c9faea25c5bb81f94e9768eR1-R9): Added a route for the blog page with a simple "Hello '/blog'!" message.