### PR TITLE
feat: make date prop optional in Card component

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,7 +1,7 @@
 interface CardProps {
 	image: string;
 	title: string;
-	date: string;
+	date?: string;
 	subtitle?: string;
 	description: string;
 	categories?: string[];


### PR DESCRIPTION
This pull request makes a small update to the `CardProps` interface in `src/components/ui/Card.tsx`. The `date` property is now optional.