### PR TITLE
Dev

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -14,15 +14,6 @@ const { t } = Astro.props;
       <div class="space-y-6">
         <div class="flex items-center gap-4">
           <div class="w-12 h-12 rounded-xl bg-primary-container text-on-primary-container flex items-center justify-center">
-            <span class="material-symbols-outlined" aria-hidden="true">mail</span>
-          </div>
-          <div>
-            <p class="text-label-sm text-on-surface-variant">{t.emailLabel}</p>
-            <p class="text-body-md font-bold">mateobetancurb@gmail.com</p>
-          </div>
-        </div>
-        <div class="flex items-center gap-4">
-          <div class="w-12 h-12 rounded-xl bg-primary-container text-on-primary-container flex items-center justify-center">
             <span class="material-symbols-outlined" aria-hidden="true">location_on</span>
           </div>
           <div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -23,6 +23,16 @@ const { t, lang } = Astro.props;
       <a class="bg-primary text-on-primary px-8 py-4 rounded-xl text-label-md hover:shadow-lg transition-all active:scale-95" href={`/${lang}/#projects`}>{t.ctaPrimary}</a>
       <a class="border-2 border-primary text-primary px-8 py-4 rounded-xl text-label-md hover:bg-surface-container transition-all active:scale-95" href={`/${lang}/#contact`}>{t.ctaSecondary}</a>
     </div>
+    <div class="flex flex-wrap gap-3">
+      <a class="inline-flex items-center gap-2 px-5 py-2.5 rounded-full text-label-md text-on-surface-variant border border-outline-variant hover:bg-surface-container hover:text-on-surface transition-all active:scale-95" href="/mateobetancur-english-cv.pdf" download>
+        <span class="material-symbols-outlined text-[18px]">download</span>
+        {t.cvEn}
+      </a>
+      <a class="inline-flex items-center gap-2 px-5 py-2.5 rounded-full text-label-md text-on-surface-variant border border-outline-variant hover:bg-surface-container hover:text-on-surface transition-all active:scale-95" href="/mateobetancur-spanish-cv.pdf" download>
+        <span class="material-symbols-outlined text-[18px]">download</span>
+        {t.cvEs}
+      </a>
+    </div>
   </div>
   <div class="relative group">
     <div class="absolute -inset-4 bg-surface-container-high rounded-3xl -z-10 group-hover:rotate-1 transition-transform"></div>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -17,6 +17,8 @@ export const ui = {
       body: "I'm a full-stack developer with over 5 years of experience specializing in TypeScript, React, Next.js, Vue, and Node.js, building high-performance web applications and scaling e-commerce platforms to over 500,000 users using AWS infrastructure.",
       ctaPrimary: 'View Projects',
       ctaSecondary: 'Contact Me',
+      cvEn: 'CV (English)',
+      cvEs: 'CV (Español)',
     },
     about: {
       headline: 'Precision-driven engineering',
@@ -149,6 +151,8 @@ export const ui = {
       body: 'Soy un desarrollador web con más de 5 años de experiencia, especializado en TypeScript, React, Next.js, Vue y Node.js, construyendo aplicaciones web de alto rendimiento y escalando plataformas de e-commerce a más de 500,000 usuarios con infraestructura AWS.',
       ctaPrimary: 'Ver Proyectos',
       ctaSecondary: 'Contáctame',
+      cvEn: 'CV (English)',
+      cvEs: 'CV (Español)',
     },
     about: {
       headline: 'Ingeniería orientada a la precisión',

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -123,7 +123,6 @@ export const ui = {
     contact: {
       headline: 'Have a project or opportunity in mind?',
       body: "I'm currently accepting new projects and consulting opportunities. Let's create something exceptional together.",
-      emailLabel: 'Email me at',
       locationLabel: 'Based in',
     },
     footer: {
@@ -256,7 +255,6 @@ export const ui = {
     contact: {
       headline: '¿Tienes un proyecto u oportunidad en mente?',
       body: 'Actualmente acepto nuevos proyectos y oportunidades de consultoría. Creemos algo excepcional juntos.',
-      emailLabel: 'Escríbeme a',
       locationLabel: 'Basado en',
     },
     footer: {


### PR DESCRIPTION
This pull request updates the landing page to add downloadable CV links in both English and Spanish, and removes the email contact information from the contact section. It also updates the translation files to support the new CV links and removes the now-unused email label.

**UI enhancements:**

* Added two new download buttons in the `Hero.astro` component for English and Spanish CVs, allowing users to download either version directly from the landing page.
* Added corresponding translation keys `cvEn` and `cvEs` for both English and Spanish in `ui.ts` to support the new CV download buttons. [[1]](diffhunk://#diff-ef401a67d5ffcbe9264ea0f58e2ee2c83507c3b258aa21768e25f232110c6cedR20-R21) [[2]](diffhunk://#diff-ef401a67d5ffcbe9264ea0f58e2ee2c83507c3b258aa21768e25f232110c6cedR154-R155)

**Contact section simplification:**

* Removed the email contact block from the `Contact.astro` component, so the email address is no longer displayed on the page.
* Removed the `emailLabel` translation key from both English and Spanish sections in `ui.ts`, since the email contact is no longer shown. [[1]](diffhunk://#diff-ef401a67d5ffcbe9264ea0f58e2ee2c83507c3b258aa21768e25f232110c6cedL126) [[2]](diffhunk://#diff-ef401a67d5ffcbe9264ea0f58e2ee2c83507c3b258aa21768e25f232110c6cedL259)